### PR TITLE
fix: BTgymBaseData's to_btfeed method should not directly use self.ti…

### DIFF
--- a/btgym/datafeed/base.py
+++ b/btgym/datafeed/base.py
@@ -26,6 +26,7 @@ import copy
 import os
 import sys
 
+from backtrader import TimeFrame
 import backtrader.feeds as btfeeds
 import pandas as pd
 
@@ -484,11 +485,16 @@ class BTgymBaseData:
         Returns:
              dict of type: {data_line_name: bt.datafeed instance}.
         """
+        def bt_timeframe(minutes):
+            timeframe = TimeFrame.Minutes
+            if minutes / 1440 == 1:
+                timeframe = TimeFrame.Days
+            return timeframe
         try:
             assert not self.data.empty
             btfeed = btfeeds.PandasDirectData(
                 dataname=self.data,
-                timeframe=self.timeframe,
+                timeframe=bt_timeframe(self.timeframe),
                 datetime=self.datetime,
                 open=self.open,
                 high=self.high,


### PR DESCRIPTION
When calling to Cerebro.run(), eventually, it will call the DataSeries getwriterinfo(), which use the timeframe as info for return value, it pass the data's timerframe to TimeFrame.TName 
![screenshot from 2018-11-14 23-29-27](https://user-images.githubusercontent.com/7583472/48492638-2ed74180-e865-11e8-96b9-0e05504b0555.png)
the default timeframe is minute base in btgym, but the default timeframe in backtrader is day, which are mismatch, in this patch, I correct the minute base and day base case.