### PR TITLE
Workaround fix for #95 - order mixup on datas

### DIFF
--- a/btgym/datafeed/multi.py
+++ b/btgym/datafeed/multi.py
@@ -10,6 +10,8 @@ import sys
 import backtrader.feeds as btfeeds
 import pandas as pd
 
+from collections import OrderedDict
+
 
 class BTgymMultiData:
     """
@@ -92,7 +94,7 @@ class BTgymMultiData:
             raise ValueError
 
         # Make dictionary of single-stream datasets:
-        self.data = {}
+        self.data = OrderedDict()
         for key, stream in self.data_config.items():
             try:
                 stream['config'].update(kwargs)
@@ -238,7 +240,7 @@ class BTgymMultiData:
         return sample
 
     def to_btfeed(self):
-        feed = {}
+        feed = OrderedDict()
         for key, stream in self.data.items():
             # Get single-dataline btfeed dict:
             feed_dict = stream.to_btfeed()

--- a/examples/multi_discrete_setup_intro.ipynb
+++ b/examples/multi_discrete_setup_intro.ipynb
@@ -34,7 +34,9 @@
     "\n",
     "from btgym import MultiDiscreteEnv\n",
     "from btgym.datafeed.casual import BTgymCasualDataDomain\n",
-    "from btgym.datafeed.multi import BTgymMultiData\n"
+    "from btgym.datafeed.multi import BTgymMultiData\n",
+    "\n",
+    "from collections import OrderedDict\n"
    ]
   },
   {
@@ -221,12 +223,14 @@
     "    },\n",
     ")\n",
     "\n",
-    "data_config = {\n",
-    "    'USD': {'filename': './data/DAT_ASCII_EURUSD_M1_2017.csv'},\n",
-    "    'GBP': {'filename': './data/DAT_ASCII_EURGBP_M1_2017.csv'},\n",
-    "    'JPY': {'filename': './data/DAT_ASCII_EURJPY_M1_2017.csv'},\n",
-    "    'CHF': {'filename': './data/DAT_ASCII_EURCHF_M1_2017.csv'},\n",
-    "}\n",
+    "data_config = [\n",
+    "    ('USD', {'filename': './data/DAT_ASCII_EURUSD_M1_2017.csv'}, ),\n",
+    "    ('GBP', {'filename': './data/DAT_ASCII_EURGBP_M1_2017.csv'}, ),\n",
+    "    ('JPY', {'filename': './data/DAT_ASCII_EURJPY_M1_2017.csv'}, ),\n",
+    "    ('CHF', {'filename': './data/DAT_ASCII_EURCHF_M1_2017.csv'}, ),\n",
+    "]\n",
+    "\n",
+    "data_config = OrderedDict(data_config)\n",
     "\n",
     "dataset = BTgymMultiData(\n",
     "    data_class_ref=BTgymCasualDataDomain,\n",


### PR DESCRIPTION
datas[] is created when we use cerebro.adddata() in sever.py but before we add the data, 2 dictionary are created on BTgymMultiData which mix the oredered data_config.

change dictionary declaration from {} to OrderedDict()