### PR TITLE
Limit tensorflow version to <2, because of incompatible changes.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     ],
     version='0.0.8',
     install_requires=[
-        'tensorflow>=1.5',
+        'tensorflow>=1.5, <2',
         'opencv-python',
         'gym[atari]',
         'backtrader',


### PR DESCRIPTION
Algorithms do not work without this limitation.